### PR TITLE
Specify license on gemspec

### DIFF
--- a/ng-rails-csrf.gemspec
+++ b/ng-rails-csrf.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |gem|
   gem.version       = Ng::Rails::Csrf::VERSION
   gem.authors       = ["Chris Dawson"]
   gem.email         = ["xrdawson@gmail.com"]
+  gem.license       = "MIT"
   gem.description   = %q{AngularJS for using CSRF token with http requests}
   gem.summary       = %q{AngularJS rails gem which you can load into any rails project to make sure CSRF token is used with Angular http requests}
   gem.homepage      = ""


### PR DESCRIPTION
Hey there,

We're using an automated tool called License Finder (https://github.com/pivotal/LicenseFinder) and your gem comes up as "Unknown". By adding the license to the gemspec file you would help immensely users of this and other automated tools to figure out whether a gem can be used inside another project.

Thanks!
